### PR TITLE
Update pom since Graph Editor's Init.js was no longer added to the webjar

### DIFF
--- a/draw.io-webjar/pom.xml
+++ b/draw.io-webjar/pom.xml
@@ -77,7 +77,7 @@
                     <exclude>js/deflate/**</exclude>
                     <exclude>js/dropbox/**</exclude>
                     <exclude>js/jscolor/**</exclude>
-                    <exclude>js/mxgraph/**</exclude>
+                    <exclude>js/grapheditor/**</exclude>
                     <exclude>js/onedrive/**</exclude>
                     <exclude>js/sanitizer/**</exclude>
                     <exclude>mxgraph/**</exclude>
@@ -94,6 +94,9 @@
                   <includes>
                     <!-- This is required by File / Open Library from / Browser... -->
                     <include>open.html</include>
+                    <!-- Some Graph Editor configurations are required since they are not covered by draw.io's
+                      initialization step. -->
+                    <include>js/grapheditor/Init.js</include>
                   </includes>
                 </resource>
               </resources>
@@ -241,7 +244,7 @@
               <includes>
                 <include>diagramly/Init.js</include>
                 <!-- Fall-back on the Graph Editor defaults. -->
-                <include>mxgraph/Init.js</include>
+                <include>grapheditor/Init.js</include>
               </includes>
             </configuration>
           </execution>


### PR DESCRIPTION
* this was caused by the fact that drawio/src/main/webapp/js/mxgraph was renamed to grapheditor in the 14.x versions
* diagram issue related to it https://github.com/xwikisas/application-diagram/issues/189