### PR TITLE
Upgrade draw.io dependency from 20.5.0 to 24.5.5

### DIFF
--- a/draw.io-api/pom.xml
+++ b/draw.io-api/pom.xml
@@ -120,6 +120,15 @@
                 <resource>
                   <directory>${draw.io.path}/src/main/java</directory>
                   <excludes>
+                    <exclude>com/mxgraph/online/AbsAuth.java</exclude>
+                    <exclude>com/mxgraph/online/AbsCache.java</exclude>
+                    <exclude>com/mxgraph/online/ServletComm.java</exclude>
+                    <exclude>com/mxgraph/online/GitlabAuth.java</exclude>
+                    <exclude>com/mxgraph/online/AtlasAuth.java</exclude>
+                    <exclude>com/mxgraph/online/GitHubAuth.java</exclude>
+                    <exclude>com/mxgraph/online/DropboxAuth.java</exclude>
+                    <exclude>com/mxgraph/online/GoogleAuth.java</exclude>
+                    <exclude>com/mxgraph/online/MSGraphAuth.java</exclude>
                     <exclude>com/mxgraph/online/AbsAuthServlet.java</exclude>
                     <exclude>com/mxgraph/online/MSGraphAuthServlet.java</exclude>
                     <exclude>com/mxgraph/online/GoogleAuthServlet.java</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <draw.io.version>20.5.0</draw.io.version>
+    <draw.io.version>24.5.5</draw.io.version>
     <mxgraph.version>4.2.2_final</mxgraph.version>
     <draw.io-gliffy.version>13.4.8</draw.io-gliffy.version>
     <!-- The path to the folder where we unpack the draw.io sources. -->


### PR DESCRIPTION
* To upgrade the dependency, I had to exclude the classes related to the Auth methods.